### PR TITLE
Ticket5752

### DIFF
--- a/DAQmxBaseApp/src/Makefile
+++ b/DAQmxBaseApp/src/Makefile
@@ -71,6 +71,13 @@ DAQmx_DBD += base.dbd
 DAQmx_DBD += DAQmxSupport.dbd
 DAQmx_DBD += asyn.dbd
 
+DAQmx_DBD += icpconfig.dbd
+DAQmx_DBD += pvdump.dbd
+DAQmx_DBD += asSupport.dbd
+DAQmx_DBD += devIocStats.dbd
+DAQmx_DBD += caPutLog.dbd
+DAQmx_DBD += utilities.dbd
+
 # DAQmxBase_registerRecordDeviceDriver.cpp will be created
 # DAQmxBase.dbd
 DAQmxBase_SRCS += DAQmxBase_registerRecordDeviceDriver.cpp
@@ -97,6 +104,13 @@ DAQmxBase_LIBS += asyn
 
 DAQmx_LIBS += DAQmxSupport
 DAQmx_LIBS += asyn
+
+DAQmx_LIBS += devIocStats 
+DAQmx_LIBS += pvdump $(MYSQLLIB) easySQLite sqlite 
+DAQmx_LIBS += caPutLog
+DAQmx_LIBS += icpconfig pugixml
+DAQmx_LIBS += autosave
+DAQmx_LIBS += utilities pcre libjson zlib
 
 # We need to link this IOC Application against the EPICS Base libraries
 DAQmxBase_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,6 +1,69 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU MAKE ANY CHANGES to this file you must subsequently
+# do a "gnumake rebuild" in this application's top level
+# directory.
+#
+# The build process does not check dependencies against files
+# that are outside this application, thus you should do a
+# "gnumake rebuild" in the top level directory after EPICS_BASE
+# or any other external module pointed to below is rebuilt.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it can ONLY contain definitions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = C:/Instrument/Apps/EPICS/base/master
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+
+# Macros required for basic ioc/stream device
+ACCESSSECURITY=$(SUPPORT)/AccessSecurity/master
+ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
 ASYN=$(SUPPORT)/asyn/master
-ONCRPC=$(SUPPORT)/oncrpc/master
+AUTOSAVE=$(SUPPORT)/autosave/master
+CALC=$(SUPPORT)/calc/master
+CAPUTLOG=$(SUPPORT)/caPutLog/master
 DAQMXBASE=$(SUPPORT)/DAQmxBase/master
+DEVIOCSTATS=$(SUPPORT)/devIocStats/master
+GSL=$(SUPPORT)/gsl/master
+ICPCONFIG=$(SUPPORT)/icpconfig/master
+LIBJSON=$(SUPPORT)/libjson/master
+MYSQL=$(SUPPORT)/MySQL/master
+ONCRPC=$(SUPPORT)/oncrpc/master
+PCRE=$(SUPPORT)/pcre/master
+PUGIXML=$(SUPPORT)/pugixml/master
+PVDUMP=$(SUPPORT)/pvdump/master
+SNCSEQ=$(SUPPORT)/seq/master
+SQLITE=$(SUPPORT)/sqlite/master
+SSCAN=$(SUPPORT)/sscan/master
+STREAMDEVICE=$(SUPPORT)/StreamDevice/master
+UTILITIES=$(SUPPORT)/utilities/master
+ZLIB=$(SUPPORT)/zlib/master
 
 # optional extra local definitions here
 -include $(TOP)/configure/RELEASE.private

--- a/iocBoot/iocDAQmx/st.cmd
+++ b/iocBoot/iocDAQmx/st.cmd
@@ -14,15 +14,17 @@ cd "${TOP}"
 dbLoadDatabase "dbd/DAQmx.dbd"
 DAQmx_registerRecordDeviceDriver pdbbase
 
+< $(IOCSTARTUP)/init.cmd
+
 ## NI cDAQ-9181 with NI 9375 card
 
 epicsEnvSet("DAQ","cDAQ1Mod3")
 
 ## port0 is input
-DAQmxConfig("myport1", "$(DAQ)/ai0", 0, "AI","N=1000 F=1000")
-DAQmxConfig("myport1", "$(DAQ)/ai1", 1, "AI","N=1000 F=1000")
-DAQmxConfig("myport1", "$(DAQ)/ai2", 2, "AI","N=1000 F=1000")
-DAQmxConfig("myport1", "$(DAQ)/ai3", 3, "AI","N=1000 F=1000")
+DAQmxConfig("myport1", "$(DAQ)/ai0", 0, "AI","$(DAQMODE=N=1000 F=1000)")
+DAQmxConfig("myport1", "$(DAQ)/ai1", 1, "AI","$(DAQMODE=N=1000 F=1000)")
+DAQmxConfig("myport1", "$(DAQ)/ai2", 2, "AI","$(DAQMODE=N=1000 F=1000)")
+DAQmxConfig("myport1", "$(DAQ)/ai3", 3, "AI","$(DAQMODE=N=1000 F=1000)")
 #asynSetTraceMask("myport0", 0, 0x11)
 
 ## Load record instances
@@ -30,3 +32,5 @@ dbLoadRecords("db/DAQmxBaseI.vdb","DAQMX=$(MYPVPREFIX)DAQMXTEST,PORT=myport1,NEL
 
 cd "${TOP}/iocBoot/${IOC}"
 iocInit
+
+$(DAQPOSTIOCINITCMD=)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/5752

Catch error if wrong number of samples is read, which is an error condition which is hit in monster mode (as monster mode does not repeatedly reopen connections, the error check there does not fire).

Makefile changes are just so that we can use standard `st.cmd` scripts.