### PR TITLE
Fix DAQmx_monster tests

### DIFF
--- a/iocBoot/iocDAQmx/st.cmd
+++ b/iocBoot/iocDAQmx/st.cmd
@@ -33,4 +33,4 @@ dbLoadRecords("db/DAQmxBaseI.vdb","DAQMX=$(MYPVPREFIX)DAQMXTEST,PORT=myport1,NEL
 cd "${TOP}/iocBoot/${IOC}"
 iocInit
 
-$(DAQPOSTIOCINITCMD=)
+$(DAQMXTEST__DAQPOSTIOCINITCMD=)


### PR DESCRIPTION
Test macros aren't passed through with the ioc_name stripped it differs from icpconfig ioc_name, so use macros that is passed through

https://github.com/ISISComputingGroup/IBEX/issues/5888