### PR TITLE
Check thermocouple channel exists before configuring

### DIFF
--- a/DAQmxBaseApp/src/drvDaqMxBase.c
+++ b/DAQmxBaseApp/src/drvDaqMxBase.c
@@ -3354,14 +3354,14 @@ static void ConfigureChannels(daqMxBasePvt * pPvt)
                 fetchAndPrintDAQError(pPvt, "### DAQmx ERROR (CreateAIThrmcpl):");
                 pPvt->state = unconfigured;
             }
-            if (DAQmxFailed(DAQmxBaseSetAIADCTimingMode(pPvt->taskHandle, pPvt->aioPvt[channel]->devicename,
-                                                        pPvt->aioPvt[channel]->timingMode)))
+            if ((pPvt->state != unconfigured) && (DAQmxFailed(DAQmxBaseSetAIADCTimingMode(pPvt->taskHandle, pPvt->aioPvt[channel]->devicename,
+                                                        pPvt->aioPvt[channel]->timingMode))))
             {
                 fetchAndPrintDAQError(pPvt, "### DAQmx ERROR (SetAIADCTimingMode):");
                 pPvt->state = unconfigured;
             }
-            if (DAQmxFailed(DAQmxBaseSetAIAutoZeroMode(pPvt->taskHandle, pPvt->aioPvt[channel]->devicename,
-                                                       pPvt->aioPvt[channel]->autoZeroMode)))
+            if ((pPvt->state != unconfigured) && (DAQmxFailed(DAQmxBaseSetAIAutoZeroMode(pPvt->taskHandle, pPvt->aioPvt[channel]->devicename,
+                                                       pPvt->aioPvt[channel]->autoZeroMode))))
             {
                 fetchAndPrintDAQError(pPvt, "### DAQmx ERROR (SetAIAutoZeroMode):");
                 pPvt->state = unconfigured;


### PR DESCRIPTION
The IOC log was growing at an alarming rate when the thermocouple (TC) channels couldn't be configured.  e.g. if the IOC (DAQMx) could not connect to the specified host.  The log was filled with multiple entries of the same two errors.

A check on duplicate error already existed which prevents multiple entries in log files.  However, this particular condition generated two alternating errors, meaning that they were still being printed.
